### PR TITLE
Kia hotfix limite de formato de img

### DIFF
--- a/views/formularioAltaInmueble.ejs
+++ b/views/formularioAltaInmueble.ejs
@@ -130,7 +130,7 @@
                 confirmVideo = 1;
             };
             
-            if(inputElement.value < 4){
+            if(inputElement.value < 5){
                 Swal.fire({
                     icon: 'error',
                     title: 'Necesita subir por lo menos 5 imágenes del inmueble',

--- a/views/formularioAltaInmueble.ejs
+++ b/views/formularioAltaInmueble.ejs
@@ -65,14 +65,14 @@
                             <p id="fileSize" class="pb-5"></p>
                         </div>
                     </label>
-                    <input type='file' multiple='multiple' accept='image/jpg, image/png, image/webp' name='uploadedImages[]' id='uploadedImages' class="hidden"/>
+                    <input type='file' multiple='multiple' accept='image/jpeg, image/png, image/webp' name='uploadedImages[]' id='uploadedImages' class="hidden"/>
                 </form>
             </div>
         </div>
     </div>
     <input type="hidden" id="imgCount" name="imgCount">
     <input type="hidden" id="sizeCount" name="sizeCount">
-    <input type="hidden" id="successRegistry" name="successRegistry">
+    <input type="hidden" id="fileFormatCheck" name="fileFormatCheck">
 
     <!-- Information Form -->
     <!-- Cambiar dependiendo del id del tipo de inmueble -->
@@ -104,7 +104,7 @@
             e.preventDefault();
             var inputElement = document.getElementById('imgCount');
             var filesSize = document.getElementById('sizeCount');
-            var successRegistry = document.getElementById('successRegistry');
+            var fileFormatCheck = document.getElementById('fileFormatCheck');
             var mapCheck = $('input[name="linkMapsBody"]').val();
             var videoCheck = $('input[name="linkVideoBody"]').val();
             var confirmMap = 0;
@@ -144,8 +144,14 @@
                     showConfirmButton: false,
                     timer: 2000
                 });
+            } else if (fileFormatCheck.value == 0){
+                Swal.fire({
+                    icon: 'error',
+                    title: 'Sólo se aceptan formatos JPG, PNG y WEBP',
+                    showConfirmButton: false,
+                    timer: 2000
+                });
             } else if (confirmVideo != 1) {
-                //console.log("estatus de video",confirmVideo);
                 Swal.fire({
                     icon: 'error',
                     title: 'Verifique que el video tenga el formato correcto',
@@ -153,7 +159,6 @@
                     timer: 2000
                 });
             } else if (confirmMap != 1){
-                //console.log("estatus de mapa",confirmMap);
                 Swal.fire({
                     icon: 'error',
                     title: 'Verifique que el mapa tenga el formato de "insertar mapa" de google maps',
@@ -313,14 +318,26 @@
             var fileCountElement = document.getElementById('fileCount');
             var fileSizeElement = document.getElementById('fileSize');
             var sizeCount = document.getElementById('sizeCount');
+            var fileFormatCheck = document.getElementById('fileFormatCheck');
+            var fileExtension = "";
             fileCountElement.innerHTML = "<p class='text-center pb-2'>Número de imágenes: <span class='font-semibold'>" + fileCount + "</span></p>";
             for (var i = 0; i < fileCount; i++) {
                 var fileName = files[i].name;
-                //console.log(files[i].size)
+                var extensionName = fileName.toString();
                 fileSize = fileSize + files[i].size;
                 var fileItem = document.createElement("p");
                 fileItem.textContent = fileName;
-                fileCountElement.appendChild(fileItem); 
+                fileCountElement.appendChild(fileItem);
+                
+                if (extensionName.lastIndexOf(".") > 0) {
+                    fileExtension = extensionName.substring(extensionName.lastIndexOf(".") + 1, extensionName.length);
+                    
+                };
+                if (fileExtension.toLowerCase() == "png" || fileExtension.toLowerCase() == "jpeg" || fileExtension.toLowerCase() == "jpg" || fileExtension.toLowerCase() == "webp") {
+                    fileFormatCheck.value = "1";
+                } else {
+                    fileFormatCheck.value = "0";
+                };
             };
             var fileSizeMB = fileSize / 1024 / 1024;
             fileSizeElement.innerHTML = "<p class='text-center pb-2'>Tamaño de las imágenes: <span class='font-semibold'>" + fileSizeMB.toFixed(2) + " MB" + "</span></p>";

--- a/views/formularioAltaInmueble.ejs
+++ b/views/formularioAltaInmueble.ejs
@@ -65,7 +65,7 @@
                             <p id="fileSize" class="pb-5"></p>
                         </div>
                     </label>
-                    <input type='file' multiple='multiple' accept='image/*' name='uploadedImages[]' id='uploadedImages' class="hidden"/>
+                    <input type='file' multiple='multiple' accept='image/jpg, image/png, image/webp' name='uploadedImages[]' id='uploadedImages' class="hidden"/>
                 </form>
             </div>
         </div>
@@ -130,7 +130,7 @@
                 confirmVideo = 1;
             };
             
-            if(inputElement.value < 5){
+            if(inputElement.value < 4){
                 Swal.fire({
                     icon: 'error',
                     title: 'Necesita subir por lo menos 5 imágenes del inmueble',


### PR DESCRIPTION
## Descripción
Limita los formatos de imágenes a JPG, PNG y WEBP

## Resumen de cambios
- Añade verificación de formato en `formularioInmueble.ejs`
- Limpia `console.log()` flotantes

## Notas (opcional)
n/a

## Antes de asignar el PR, TODOS los checkbox deben estar marcados

- [x] ¿Ya agregaste el tiempo de la actividad al plan?

- [ ] En caso de aplicar, ¿Ya pasó las pruebas unitarias?

- [x] En caso de no aplicar con pruebas unitarias, ¿Ya probaste las funciones de forma manual?

- [x] ¿No se modifican más de 5 archivos?

- [x] ¿Se apega al estándar de código?

- [x] ¿Contiene JAVADOC en las funciones correspondientes?

- [ ] En caso de instalar una nueva dependencia o agregar algún archivo que todos deban agregar de forma local (por estar en gitignore) ¿Ya lo comunicaste al equipo?

## Antes de aceptar el PR y hacer merge, TODOS los checkbox deben estar marcados

- [ ] En caso de aplicar, ¿Ya corriste las pruebas unitarias de forma local en la rama?

- [ ] ¿Ya revisaste todos los cambios en archivos?

- [ ] ¿El código se apega al estándar definido?

- [ ] ¿El código está comentado con JAVADOC?
